### PR TITLE
Consistent version in build/runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+VERSION
 .pulumi
 bin/
 sdk/**/bin/

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ bin/venv:		${SRC}/requirements.txt
 	python -m venv $@
 	./bin/venv/bin/python -m pip install -r $<
 
-bin/${PACK}_provider:	${SRC}/
+bin/${PACK}_provider:	${SRC}/	${SRC}/${PACK}_provider/VERSION
 	rm -rf $@
 	./bin/venv/bin/python -m pip install provider/cmd/pulumi-resource-${PACK}/ -t bin/
 
@@ -42,6 +42,9 @@ bin/run-provider.py:			${SRC}/run-provider.py
 
 bin/%:
 	cp -f $< $@
+
+${SRC}/${PACK}_provider/VERSION:
+	echo "${VERSION}" > ${SRC}/${PACK}_provider/VERSION
 
 # Go SDK
 

--- a/provider/cmd/pulumi-resource-xyz/setup.py
+++ b/provider/cmd/pulumi-resource-xyz/setup.py
@@ -1,11 +1,23 @@
 from distutils.core import setup
+import os.path
+
+
+PKG = 'xyz_provider'
+
+
+def read_version():
+    with open(os.path.join(os.path.dirname(__file__), PKG, 'VERSION')) as version_file:
+        version = version_file.read().strip()
+    return version
+
 
 setup(
-    name='xyz_provider',
-    version='0.0.1',
+    name=PKG,
+    version=read_version(),
     description='XYZ Pulumi Provider',
-    packages=['xyz_provider'],
-    package_data={'xyz_provider': ['py.typed']},
+    packages=[PKG],
+    package_data={PKG: ['py.typed', 'VERSION']},
     zip_safe=False)
+
 
 ## TODO Correct Pulumi SDK dependency information

--- a/provider/cmd/pulumi-resource-xyz/xyz_provider/__init__.py
+++ b/provider/cmd/pulumi-resource-xyz/xyz_provider/__init__.py
@@ -1,0 +1,5 @@
+import os.path
+
+
+with open(os.path.join(os.path.dirname(__file__), 'VERSION')) as version_file:
+    __version__ = version_file.read().strip()

--- a/provider/cmd/pulumi-resource-xyz/xyz_provider/provider.py
+++ b/provider/cmd/pulumi-resource-xyz/xyz_provider/provider.py
@@ -18,14 +18,14 @@ from pulumi import Inputs, ResourceOptions
 from pulumi.provider import ConstructResult
 import pulumi.provider as provider
 
+import xyz_provider
 from xyz_provider.staticpage import StaticPage, StaticPageArgs
 
 
 class Provider(provider.Provider):
-    VERSION = "0.0.1"
 
     def __init__(self) -> None:
-        super().__init__(Provider.VERSION)
+        super().__init__(xyz_provider.__version__)
 
     def construct(self,
                   name: str,


### PR DESCRIPTION
Following one of the more conservative options from https://packaging.python.org/guides/single-sourcing-package-version/

So that:

- VERSION is spec'd once in Makefile
- setup.py labels xyz_provider package with the VERSION
- at runtime you can read the same thing back as `import xyz_provider; xyz_provider.__version__`
- Pulumi provider is marked with the same version in the `super()` call