### PR TITLE
fix this template so it doesn't barf

### DIFF
--- a/provider/cmd/pulumi-resource-xyz/xyz_provider/__init__.py
+++ b/provider/cmd/pulumi-resource-xyz/xyz_provider/__init__.py
@@ -3,5 +3,5 @@ import os.path
 with open(os.path.join(os.path.dirname(__file__), 'VERSION')) as version_file:
     __version__ = version_file.read().strip()
 
-with open(os.path.join(os.path.dir(__file__), 'schema.json')) as schema_file:
-    __schema__ = schema_file.read().string()
+with open(os.path.join(os.path.dirname(__file__), 'schema.json')) as schema_file:
+    __schema__ = schema_file.read().strip()


### PR DESCRIPTION
fixes the following problem:
```
  pulumi:pulumi:Stack (pulumi-noom-yaml-pulumi-noom-yaml):
    Traceback (most recent call last):
      File "/Users/allixsenos/.pulumi/plugins/resource-noom-v0.0.1/run-provider.py", line 19, in <module>
        import noom_provider
      File "/Users/allixsenos/.pulumi/plugins/resource-noom-v0.0.1/noom_provider/__init__.py", line 6, in <module>
        with open(os.path.join(os.path.dir(__file__), 'schema.json')) as schema_file:
    AttributeError: module 'posixpath' has no attribute 'dir'
```

only the schema reading has these two typos (copypastas?), the version reading part doesn't